### PR TITLE
Remove 74 duplicated lines; add findDups.sh script to find duplicated lines.

### DIFF
--- a/findDups.sh
+++ b/findDups.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cut -d, -f1 lineages.csv |sort | uniq -c | awk '$1 > 1 {print $2;}' | grep -Fwf - lineages.csv | sort -u


### PR DESCRIPTION
74 lines were duplicated, fortunately without any conflicting lineages, so I removed them.  I added a script with the command pipe that I used to find the duplicated lines.  You can run it like this to find IDs that appear more than once:

`./findDups.sh`

* No output is good (each sequence name appears only once in lineage.csv).
* If a sequence name appears only once in the output, then the whole line is duplicated (no conflicting assignment) and extra instance(s) of the line can simply be removed.  For example:
`Lithuania/NMRVI70065/2021,Q.1`
* If a sequence name appears more than once, then conflicting lineages have been designated and will need to be resolved.  For example:
`Hypothetical_conflicting_sequence,B.1`
`Hypothetical_conflicting_sequence,B.1.1`

