### PR TITLE
Name updates & removal of retracted sequences

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -1379,6 +1379,7 @@ AY.29	Alias of B.1.617.2.29, Japan lineage, from pango-designation issue #208
 AY.30	Alias of B.1.617.2.30, Thailand and Cambodia lineage, from pango-designation issue #207
 AY.31	Alias of B.1.617.2.31, lineage associated with Myanmar. At the time of designation, almost all sequences in this lineage were from Myanmar or had travel history from Myanmar, from pango-designation issue #206
 AY.32	Alias of B.1.617.2.32, South Africa lineage, from pango-designation issue #209
+AY.33	Alias of B.1.617.2.33, Lineage with 4 new spike mutations circulating mostly in Belgium, Denmark, France, Netherlands, Germany, from pango-designation issue #215
 XA	Recombinant lineage with parental lineages B.1.1.7 and B.1.177, UK lineage
 *A.2.1	Withdrawn: Lineage with sequences predominantly from Panama
 *A.8	Withdrawn: Indian lineage merged with A.9


### PR DESCRIPTION
Update names that have changed in GISAID and remove sequences that are no longer in GISAID.

I searched for sequence names that did not appear in my local piecewise-downloaded GISAID data and did a lot of checking vs. the GISAID website to confirm name changes or retracted sequences.  Some name updates led to duplications (i.e. both old and new name were used) so I removed old names in those rare cases.  I did not exhaustively check almost 10k COG-UK sequence names not found in GISAID because I assume you pull those from COG-UK not GISAID anyway.

Someone with a GISAID data feed could do this more thoroughly than I could :) and it would be even better if EPI_ISL IDs could be incorporated into lineages.csv, for example by appending them to names like "SouthAfrica/NICD-N00628/2020|EPI_ISL_940086".  How much work would it be for whatever processes consume lineages.csv to parse 'name|EPI_ISL_#' instead of just name?