### PR TITLE
Add GitHub Action for JSON validation

### DIFF
--- a/.github/workflows/check_json.yml
+++ b/.github/workflows/check_json.yml
@@ -1,0 +1,18 @@
+name: JSON check
+
+on:
+  push:
+    paths:
+      - '**.json'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "\\.json$"


### PR DESCRIPTION
This PR would create a GitHub action to validate JSON files for syntax (there's currently a small issue with a trailing comma at the end of https://github.com/cov-lineages/pango-designation/blob/master/pango_designation/alias_key.json)