### PR TITLE
Format corrections for lineage_notes.txt

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -984,6 +984,7 @@ BQ.1.6	Alias of B.1.1.529.5.3.1.1.1.1.1.6, US lineage, defined by ORF1a:G94C
 BQ.1.7	Alias of B.1.1.529.5.3.1.1.1.1.1.7, defined by S:L54F
 BQ.1.8	Alias of B.1.1.529.5.3.1.1.1.1.1.8, defined by ORF1a:S505F and S:Y144-, issue #1202
 BQ.1.9	Alias of B.1.1.529.5.3.1.1.1.1.1.9, US lineage, defined by ORF1a:V2604I followed by S:346T (independent from BQ.1.1)
+BQ.1.10	Alias of B.1.1.529.5.3.1.1.1.1.1.10, international lineage, 27600T
 BE.1.2	Alias of B.1.1.529.5.3.1.1.2, mainly found in Costa Rica and USA, from pango-designation issue #923
 BE.1.1.2	Alias of B.1.1.529.5.3.1.1.1.2, Germany lineage, defined by ORF9b:S50L
 CC.1	Alias of B.1.1.529.5.3.1.1.1.2.1, Germany lineage, defined by S:N450D

--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -804,6 +804,7 @@ BM.4	Alias of B.1.1.529.2.75.3.4, mainly found in India, defined by ORF1a:Q1198K
 BM.4.1	Alias of B.1.1.529.2.75.3.4.1, mainly found in India, defined by S:F486S, from pango-designation issue #957
 BM.4.1.1	Alias of B.1.1.529.2.75.3.4.1.1, mainly found in India, defined by S:346T
 CH.1	Alias of B.1.1.529.2.75.3.4.1.1.1, defined by S:K444T, issue #1113
+CH.1.1	Alias of B.1.1.529.2.75.3.4.1.1.1.1, defined by S:L452R, issue #1113
 CH.2	Alias of B.1.1.529.2.75.3.4.1.1.2, defined by S:Q183H
 BM.5	Alias of B.1.1.529.2.75.3.5, mainly found in India, defined by S:L455S, from pango-designation issue #1047
 BA.2.75.4	Alias of B.1.1.529.2.75.4, mainly found in India, pango-designation issue #935


### PR DESCRIPTION
I found lineage_notes.txt to have some inconsistencies in the use of tab-separation and missing specification of alias. So here is an attempt to correct that.