### PR TITLE
Add some issue refs without milestones

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -2921,7 +2921,7 @@ XBB.1.14.1	S:N148T, N:A211S, Russia
 XBB.1.15	ORF1a:A540V on ORF8:G8* polytomy, Colombia, USA, Guatemala, and Mexico. Automatically inferred by https://github.com/jmcbroome/autolin.
 XBB.1.15.1	S:486P, A19464G, C9803T, Brazil/Chile/USA
 XBB.1.16	Defined by S:E180V, S:478R, found in India, USA, Singapore, and Europe, from pango-designation issue #1723
-XBB.1.16.1	Defined by S:T547I
+XBB.1.16.1	Defined by S:T547I, from #1772
 FU.1	Alias of XBB.1.16.1.1, T3802C
 FU.2	Alias of XBB.1.16.1.2, C8692T
 FU.2.1	Alias of XBB.1.16.1.2.1, S:E619Q, Vietnam
@@ -3035,7 +3035,7 @@ XBB.1.45.1	S:486P, A3139G, A19137G, C28291T, USA/Portugal From #1937
 XBB.1.46	ORF1a:C1114F, Singapore/Malaysia
 XBB.1.47	ORF1a:T1761I, ORF1a:C2180Y, ORF1a:I2854V, Philippines/Singapore/Japan
 XBB.1.47.1	S:486P, S:A260V, S:V1122G, Japan/USA/Australia/Germany
-XBB.1.48	S:L455F, S:F456L (22928C), C2509T, Pakistan
+XBB.1.48	S:L455F, S:F456L (22928C), C2509T, Pakistan, from #1681
 XBB.1.49	S:346S, S:486P, on C16648A, A27965G, pre ORF8:8* branch with XBB.1.33, Somalia from sars-cov-2-variants/lineage-proposals#208
 XBB.2	Defined by S:D253G, from issue #1173
 XBB.2.1	Defined by S:N764R (C23853G), two step mutation on top of C23854A (S:N764K defining of all Omicrons)


### PR DESCRIPTION
I find some designated lineages are actually from issues without milestones. 

Manually add some of them.