### PR TITLE
Revert "Designate AY.3.5 (S:Q52H, USA) with 450 seqs (historic lineage)"

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -2258,7 +2258,6 @@ AY.3.1	Alias of B.1.617.2.3.1, USA lineage, from pango-designation issue #147
 AY.3.2	Alias of B.1.617.2.3.2, Peru lineage, from pango-designation issue #312
 AY.3.3	Alias of B.1.617.2.3.3, USA lineage, from pango-designation issue #365
 AY.3.4	Alias of B.1.617.2.3.4, Bahrain lineage
-AY.3.5	Alias of B.1.617.2.3.5, S:Q52H, USA
 AY.4	Alias of B.1.617.2.4, UK lineage, from pango-designation issue #180
 AY.4.1	Alias of B.1.617.2.4.1, UK lineage, from pango-designation issue #214
 AY.4.2	Alias of B.1.617.2.4.2, predominantly UK lineage, from pango-designation issue #223


### PR DESCRIPTION
This reverts commit 75e6f346fec925b9e4230532b0caf41a2f0e3e2c.

Reasons:
1. This branch died out over two years ago.  If it has any historical significance, that has not been noted.
2. Conflict between lineage_notes.txt, which says it has S:Q52H, and lineages.csv, in which most sequences designated as AY.3.5 are from a larger branch, a couple mutations before S:Q52H (G21718T).