### PR TITLE
Withdraw lineage KD.5

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -3642,7 +3642,6 @@ KD.1	Alias of XBC.1.3.1.1, S:R346S, Australia, from sars-cov-2-variants/lineage-
 KD.2	Alias of XBC.1.3.1.2, ORF1a:M3661L, ORF1a:M3934I, Australia/New Zealand
 KD.3	Alias of XBC.1.3.1.3, C10519T, C19524T, New Zealand
 KD.4	Alias of XBC.1.3.1.4, ORF1a:K394R, ORF1a:L730F, ORF1a:T965I, Australia/Japan
-KD.5	Alias of XBC.1.3.1.5, S:L244F, Australia
 XBC.1.4	Australia, S:G184S, from #1622
 XBC.1.5	Philippines/South Korea/Japan, ORF1a:T708I after A10042C, from #1671
 XBC.1.6	S:346S, S:M452R, found in Australia, from #1755
@@ -4030,4 +4029,5 @@ XDK	Recombinant lineage of XBB.1.16.11 (likely) and JN.1.1.1 (breakpoint between
 *HK.1.1	Withdrawn as smaller than thought (only 6 sequences have 257V and G22927T): Alias of XBB.1.9.2.5.1.1.1.1, S:455F (G22927T), China
 *HK.10	Withdrawn unless lineage grows: Alias of XBB.1.9.2.5.1.1.10, S:L455F, on C19983T branch, China
 *HK.3.11	Withdrawn, as part of 14988C sublineage of EG.5.1.1, not HK.3: Alias of XBB.1.9.2.5.1.1.3.11, S:A475V, Finland/Denmark/Sweden
+*KD.5	Withdrawn: Alias of XBC.1.3.1.5, S:L244F, Australia, indel artefact caused false S:L244F (#2405)
 


### PR DESCRIPTION
An indel artefact caused the false appearance of S:L244F as explained in #2405.

The deleted range is now masked in XBC in the usher tree so there is no longer a branch for this lineage.