### PR TITLE
Update lineage_notes.txt

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -1165,7 +1165,7 @@ KP.2.3.2	Alias of B.1.1.529.2.86.1.1.11.1.2.3.2, S:G184V
 KP.2.3.3	Alias of B.1.1.529.2.86.1.1.11.1.2.3.3, S:N185T
 KP.2.3.4	Alias of B.1.1.529.2.86.1.1.11.1.2.3.4, S:445P, A15759G, C27804T, from sars-cov-2-variants/lineage-proposals#1596
 KP.2.3.5	Alias of B.1.1.529.2.86.1.1.11.1.2.3.5, S:K535T, A1087G
-KP.2.3.6	Alias of B.1.1.529.2.86.1.1.11.1.2.3.6, S:T572I
+KP.2.3.6	Alias of B.1.1.529.2.86.1.1.11.1.2.3.6, S:T572I on a C28714T branch
 KP.2.4	Alias of B.1.1.529.2.86.1.1.11.1.2.4, S:T250N, from sars-cov-2-variants/lineage-proposals#1524
 KP.2.5	Alias of B.1.1.529.2.86.1.1.11.1.2.5, S:N185D, from sars-cov-2-variants/lineage-proposals#1527
 KP.2.6	Alias of B.1.1.529.2.86.1.1.11.1.2.6, S:W64R, S:F32del


### PR DESCRIPTION
I have added the nucleotide silent mutation that defines the branch where emereged KP.2.3.6 to avoid confusion with other undesignated branches with S:T572I . (thx @aviczhl2 for the headsup)