### PR TITLE
v1.33 fixes: retract MC.34, fix NF.1.4 designations

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -1380,7 +1380,6 @@ MC.32.1	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.32.1, S:R346T, S:H445R, ORF1a:T10
 MC.33	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.33, ORF1b:R1736K, from #2851
 MC.33.1	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.33.1, S:R346T, S:H445R, from #2851
 MC.33.2	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.33.2, S:R346T, S:S929T, from #2851
-MC.34	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.34, A29716T
 MC.35	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.35, C10432T
 MC.36	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.36, ORF1a:K141R
 MC.36.1	Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.36.1, ORF1a:H110Y
@@ -4947,3 +4946,4 @@ XFH	Recombinant lineage of LF.7.1, XEF, LF.7.1 (breakpoints: 22133-22565, 23040-
 *KR.2	Redesignated as LT.1 (JN.1.1.3.1) due to lack of C9142T
 *KP.2.14.1	Redesignated as KP.2.14: there's no good evidence for KP.2.14 lacking S:T22N in any sequences. Hence make KP.2.14.1 -> KP.2.14 and require S:T22N
 *PC.2	Redesignated as LF.7.9, S:L441R, S:H445P, Wales/Scotland, from sars-cov-2-variants/lineage-proposals#2395
+*MC.34	Withdrawn: Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.34, A29716T (29716 in UTR masked by pangolin)


### PR DESCRIPTION
This fixes some lineages.csv issues that would affect the next pangolin-data release:
* (typo) NF.1.4 sequences were misdesignated as NF.1.5
* #2916

@corneliusroemer can you confirm?  Thanks!