### PR TITLE
added the AA to the definig mutation of NL.6.1

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -1147,7 +1147,7 @@ NL.5	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.5, ORF1a:M731I, Israel
 NL.5.1	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.5.1, S:T572I
 NL.5.2	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.5.2, S:R190S, from sars-cov-2-variants/lineage-proposals#1771
 NL.6	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.6, S:V1176F, ORF1b:R1687C, from sars-cov-2-variants/lineage-proposals#2027
-NL.6.1	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.6.1, ORF1a:L3754
+NL.6.1	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.6.1, ORF1a:L3754F
 NL.7	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.7, S:S256L, N:N47Y, from sars-cov-2-variants/lineage-proposals#2069
 NL.8	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.8, ORF3a:S171L
 NL.9	Alias of B.1.1.529.2.86.1.1.9.2.1.3.1.9, S:R237K, S:K478I, from sars-cov-2-variants/lineage-proposals#2429


### PR DESCRIPTION
h/t by @Walde1nsamkeit who highlighted me the AA was missing since the first designation and i failed to correct in my previous PR