### PR TITLE
XEK.7: added mutation in the insertion as defining

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -4823,7 +4823,7 @@ XEK.5	C478T
 XEK.5.1	S:A262D
 XEK.5.2	S:R346T
 XEK.6	S:Y1155F, from sars-cov-2-variants/lineage-proposals#2088
-XEK.7	C27429T
+XEK.7	S:ins16IPLF, C27429T
 XEK.8	S:T572I
 XEL	Recombinant lineage of KS.1.1.2, JN.1 (breakpoint: 22929-24820), South Korea, from #2751
 XEL.1	S:V1264L(G25352T), from sars-cov-2-variants/lineage-proposals#2284


### PR DESCRIPTION
XEK.7 has S:ins16IPLF also.
it was tracked since long time as branch 79 on https://github.com/sars-cov-2-variants/lineage-proposals/issues/2088 by @xz-keg and @Walde1nsamkeit  the latter originally found it . All of them have the insertion mutated From MPLF to IPLF