### PR TITLE
Consistency checker for lineages.csv and lineage_notes.txt

### DIFF
--- a/.github/workflows/compare_csv_notes.yml
+++ b/.github/workflows/compare_csv_notes.yml
@@ -1,0 +1,19 @@
+name: Compare lineages.csv and lineage_notes.txt
+on:
+  push:
+    paths:
+      - 'lineages.csv'
+      - 'lineage_notes.txt'
+  pull_request:
+    paths:
+      - 'lineages.csv'
+      - 'lineage_notes.txt'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Search for lineages in lineages_notes.txt but not in lineages.csv and vice versa
+        run: python utils/check_lineages_notes.py

--- a/utils/check_lineages_notes.py
+++ b/utils/check_lineages_notes.py
@@ -1,0 +1,60 @@
+"""
+Check the lineages designated in lineages.csv against the lineages described in lineage_notes.txt.
+If they match, exit with code 0.  If there are discrepancies, exit with code 1.
+"""
+
+import csv
+import sys
+
+
+# These lineages don't have directly observed sequences and are defined as the putative
+# common ancestor of their sublineages.  Therefore, there are no sequences for them in lineages.csv,
+# so it's OK that they are in lineage_notes.txt but not in lineages.csv.
+lineages_ignore_not_in_csv = set(["B.1.1.529", "B.1.640", "BA.3.2"])
+
+
+def load_lineages(lineages_file):
+    lineages = set()
+    with open(lineages_file, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            lineage = row['lineage'].strip()
+            if lineage:
+                lineages.add(lineage)
+    return lineages
+
+
+def load_notes(notes_file):
+    notes = set()
+    with open(notes_file, 'r') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            lineage = row['Lineage'].strip()
+            # Ignore withdrawn lineages (those starting with '*')
+            if lineage and not lineage.startswith('*'):
+                notes.add(lineage)
+    return notes
+
+
+def check_lineages_notes(lineages_file, notes_file):
+    csv = load_lineages(lineages_file)
+    notes = load_notes(notes_file) - lineages_ignore_not_in_csv
+
+    if csv == notes:
+        sys.exit(0)
+    else:
+        csv_not_notes = csv - notes
+        notes_not_csv = notes - csv
+        if csv_not_notes:
+            print("\nError: Lineages in lineages.csv but not in lineage_notes.txt:")
+            for lineage in sorted(csv_not_notes):
+                print(f"  {lineage}")
+        if notes_not_csv:
+            print("\nError: Lineages in lineage_notes.txt but not in lineages.csv:")
+            for lineage in sorted(notes_not_csv):
+                print(f"  {lineage}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    check_lineages_notes("lineages.csv", "lineage_notes.txt")


### PR DESCRIPTION
Recently there have been several cases of new lineages making their way into lineage_notes.txt without having any designated sequences in lineages.csv.  This PR adds a script to highlight any differences in the sets of lineages defined in the two files and a github workflow to run the script when either or both files are updated.  Installing the script as a git pre-commit hook might also be helpful.