### PR TITLE
Add Orf9b:S10F mutation to XFN.2.1

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -5429,7 +5429,7 @@ XFM	Recombinant lineage of LF.7.6.2, LS.2.1.1 (breakpoints: 22600-22892), from #
 XFN	Recombinant lineage of XEC.25.1, LF.7, XEC.25.1 (breakpoints: 16601-18656, 22600-22864), from sars-cov-2-variants/lineage-proposals#2562
 XFN.1	T28600C
 XFN.2	ORF1b:G1772S
-XFN.2.1	S:K484R, ORF1a:P1921S, ORF1b:A374S, UK
+XFN.2.1	S:K484R, ORF1a:P1921S, ORF1b:A374S, Orf9b:S10F, UK
 XFP	Recombinant lineage of LS.2.1.1, LF.7, LS.2.1.1 (breakpoints: 8819-12891, 22133-22883), from #2969
 XFP.1	S:N477D, India, from sars-cov-2-variants/lineage-proposals#2642
 XFP.1.1	ORF1a:E457D


### PR DESCRIPTION
C28312T hence all XFN.2.1 have Orf9b:P10S further mutated to F (As BQ.1)