### PR TITLE
Update S:G1058R to S:G1085R in lineage notes (PQ.2.15)

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -5056,7 +5056,7 @@ PQ.2.13	Alias of XDV.1.5.1.1.8.1.2.13, C27513T
 PQ.2.13.1	Alias of XDV.1.5.1.1.8.1.2.13.1, S:S221L, S:S446T
 PQ.2.14	Alias of XDV.1.5.1.1.8.1.2.14, C16293T
 PQ.2.14.1	Alias of XDV.1.5.1.1.8.1.2.14.1, S:I478T (rev), S:K679R 
-PQ.2.15	Alias of XDV.1.5.1.1.8.1.2.15, S:T941S, S:G1058R
+PQ.2.15	Alias of XDV.1.5.1.1.8.1.2.15, S:T941S, S:G1085R
 PQ.3	Alias of XDV.1.5.1.1.8.1.3, N:H300Y, N:G321S, from sars-cov-2-variants/lineage-proposals#2578
 PQ.4	Alias of XDV.1.5.1.1.8.1.4, C2842T
 PQ.4.1	Alias of XDV.1.5.1.1.8.1.4.1, S:T572I, S:K679N, from sars-cov-2-variants/lineage-proposals#2773


### PR DESCRIPTION
PQ.2.15 : There was a typo S:G1058R is instead S:G1085R